### PR TITLE
[HGNN-10619] 알림 : 디바이스 알림 설정 > 알림 방식 > 배너 미포함 시 알림 허용 OFF 상태로 인식

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -333,7 +333,7 @@ static NSMutableArray* pendingGlobalJS = nil;
         [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
             @try {
                 BOOL enabled = NO;
-                if (settings.alertSetting == UNNotificationSettingEnabled) {
+                if (settings.authorizationStatus == UNAuthorizationStatusAuthorized) {
                     enabled = YES;
                     [self registerForRemoteNotifications];
                 }


### PR DESCRIPTION
### 관련이슈
  https://zigbang.atlassian.net/browse/HGNN-10619

### 원인 및 수정
  - 플러그인에서 hasPermission 여부를 settings.alertSetting 값으로 판단
  - 배너설정이 꺼져있으면 알림설정도 꺼져 있다고 간주
  - 전체알림 허용여부를 판단하는 플래그값으로 허용 여부 판단하도록 수정

참고: https://developer.apple.com/documentation/usernotifications/unnotificationsettings