### PR TITLE
[HGNN-12011] WebView 재시작 시 Deeplink 유실 문제

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebasex",
-  "version": "18.1.2-hogangnono-dev-1",
+  "version": "18.1.2-hogangnono-dev-2",
   "description": "Cordova plugin for Google Firebase",
   "types": "./types/index.d.ts",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebasex",
-  "version": "18.1.2-hogangnono-dev-2",
+  "version": "18.1.2-hogangnono-dev-3",
   "description": "Cordova plugin for Google Firebase",
   "types": "./types/index.d.ts",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebasex",
-  "version": "18.1.2-hogangnono",
+  "version": "18.1.2-hogangnono-dev-1",
   "description": "Cordova plugin for Google Firebase",
   "types": "./types/index.d.ts",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebasex",
-  "version": "18.1.2-hogangnono-dev-3",
+  "version": "18.1.2-hogangnono-dev-4",
   "description": "Cordova plugin for Google Firebase",
   "types": "./types/index.d.ts",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebasex",
-  "version": "18.1.2-hogangnono-dev-6",
+  "version": "18.1.3-hogangnono",
   "description": "Cordova plugin for Google Firebase",
   "types": "./types/index.d.ts",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebasex",
-  "version": "18.1.2-hogangnono-dev-4",
+  "version": "18.1.2-hogangnono-dev-6",
   "description": "Cordova plugin for Google Firebase",
   "types": "./types/index.d.ts",
   "author": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-2"
+<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-3"
 	xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-3"
+<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-4"
 	xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-1"
+<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-2"
 	xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-firebasex" version="18.1.1-hogangnono"
+<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-1"
 	xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-4"
+<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-6"
 	xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-firebasex" version="18.1.2-hogangnono-dev-6"
+<plugin id="cordova-plugin-firebasex" version="18.1.3-hogangnono"
 	xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -164,10 +164,6 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
     NSLog(@"FCM_TEST: WEBVIEW_RESTART_CHECK - notificationStack count: %lu", FirebasePlugin.firebasePlugin.notificationStack ? (unsigned long)[FirebasePlugin.firebasePlugin.notificationStack count] : 0);
     NSLog(@"FCM_TEST: WEBVIEW_RESTART_CHECK - notificationCallbackId: %@", FirebasePlugin.firebasePlugin.notificationCallbackId ? @"SET" : @"NIL");
 
-    // 웹뷰 상태는 WKWebView delegate에서 관리됨 (webViewReady 플래그)
-    extern BOOL webViewReady;
-    NSLog(@"FCM_TEST: FOREGROUND_ENTRY - Current webViewReady: %@", webViewReady ? @"YES" : @"NO");
-
     self.applicationInBackground = @(NO);
     @try {
         [FirebasePlugin.firebasePlugin _logMessage:@"Enter foreground"];

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -49,9 +49,6 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
 - (BOOL)application:(UIApplication *)application swizzledDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [self application:application swizzledDidFinishLaunchingWithOptions:launchOptions];
 
-    NSLog(@"FCM_TEST: AppDelegate didFinishLaunching started");
-    NSLog(@"SIMPLE_TEST: AppDelegate didFinishLaunching started");
-
     #if DEBUG
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"/google/firebase/debug_mode"];
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"/google/measurement/debug_mode"];
@@ -144,14 +141,11 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
         }];
 
         self.applicationInBackground = @(YES);
-        NSLog(@"FCM_TEST: AppDelegate didFinishLaunching completed successfully");
 
     }@catch (NSException *exception) {
-        NSLog(@"FCM_TEST: AppDelegate didFinishLaunching failed: %@", exception.reason);
         [FirebasePlugin.firebasePlugin handlePluginExceptionWithoutContext:exception];
     }
 
-    NSLog(@"FCM_TEST: AppDelegate didFinishLaunching returning YES");
     return YES;
 }
 
@@ -160,36 +154,22 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-    NSLog(@"FCM_TEST: applicationDidBecomeActive - App entering foreground");
-    NSLog(@"FCM_TEST: WEBVIEW_RESTART_CHECK - notificationStack count: %lu", FirebasePlugin.firebasePlugin.notificationStack ? (unsigned long)[FirebasePlugin.firebasePlugin.notificationStack count] : 0);
-    NSLog(@"FCM_TEST: WEBVIEW_RESTART_CHECK - notificationCallbackId: %@", FirebasePlugin.firebasePlugin.notificationCallbackId ? @"SET" : @"NIL");
-
     self.applicationInBackground = @(NO);
     @try {
         [FirebasePlugin.firebasePlugin _logMessage:@"Enter foreground"];
-        NSLog(@"FCM_TEST: Executing global JS: applicationDidBecomeActive");
         [FirebasePlugin.firebasePlugin executeGlobalJavascript:@"FirebasePlugin._applicationDidBecomeActive()"];
-
-        // 글로벌 JS 실행 (웹뷰 준비 상태는 WKWebView delegate에서 관리)
-        NSLog(@"FCM_TEST: GLOBAL_JS_EXECUTED - applicationDidBecomeActive JS executed");
-
-        NSLog(@"FCM_TEST: Calling sendPendingNotifications from applicationDidBecomeActive");
         [FirebasePlugin.firebasePlugin sendPendingNotifications];
     }@catch (NSException *exception) {
-        NSLog(@"FCM_TEST: Exception in applicationDidBecomeActive: %@", exception.reason);
         [FirebasePlugin.firebasePlugin handlePluginExceptionWithoutContext:exception];
     }
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application {
-    NSLog(@"FCM_TEST: applicationDidEnterBackground - App entering background");
     self.applicationInBackground = @(YES);
     @try {
         [FirebasePlugin.firebasePlugin _logMessage:@"Enter background"];
-        NSLog(@"FCM_TEST: Executing global JS: applicationDidEnterBackground");
         [FirebasePlugin.firebasePlugin executeGlobalJavascript:@"FirebasePlugin._applicationDidEnterBackground()"];
     }@catch (NSException *exception) {
-        NSLog(@"FCM_TEST: Exception in applicationDidEnterBackground: %@", exception.reason);
         [FirebasePlugin.firebasePlugin handlePluginExceptionWithoutContext:exception];
     }
 }
@@ -219,12 +199,11 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
     fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
-    NSLog(@"FCM_TEST: didReceiveRemoteNotification called");
-    NSLog(@"FCM_TEST: App state - background: %@", self.applicationInBackground);
-    NSLog(@"FCM_TEST: Raw userInfo: %@", userInfo);
+    NSLog(@"📨 [AppDelegate] didReceiveRemoteNotification called");
+    NSLog(@"📨 [AppDelegate] Raw userInfo: %@", userInfo);
 
     if (!self.isFCMEnabled) {
-        NSLog(@"FCM_TEST: FCM is not enabled - returning early");
+        NSLog(@"❌ [AppDelegate] FCM is not enabled");
         return;
     }
 
@@ -234,44 +213,36 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
         NSDictionary* aps = [mutableUserInfo objectForKey:@"aps"];
         bool isContentAvailable = false;
 
-        NSLog(@"FCM_TEST: APS data: %@", aps);
+        NSLog(@"📨 [AppDelegate] APS data: %@", aps);
 
         if([aps objectForKey:@"alert"] != nil){
-            NSLog(@"FCM_TEST: APS alert found - this is a notification message");
 
             if([aps objectForKey:@"content-available"] != nil){
                 NSNumber* contentAvailable = (NSNumber*) [aps objectForKey:@"content-available"];
                 isContentAvailable = [contentAvailable isEqualToNumber:[NSNumber numberWithInt:1]];
-                NSLog(@"FCM_TEST: Content available: %@", isContentAvailable ? @"YES" : @"NO");
+                NSLog(@"📨 [AppDelegate] Content available: %@", isContentAvailable ? @"YES" : @"NO");
             }
             [mutableUserInfo setValue:@"notification" forKey:@"messageType"];
             NSString* tap;
             if([self.applicationInBackground isEqual:[NSNumber numberWithBool:YES]] && !isContentAvailable){
                 tap = @"background";
-                NSLog(@"FCM_TEST: Setting tap to 'background' (app in background and not content-available)");
             }
             [mutableUserInfo setValue:tap forKey:@"tap"];
         }else{
-            NSLog(@"FCM_TEST: No APS alert - this is a data message");
             [mutableUserInfo setValue:@"data" forKey:@"messageType"];
         }
 
-        NSLog(@"FCM_TEST: Processed userInfo: %@", mutableUserInfo);
+        NSLog(@"📨 [AppDelegate] Processed userInfo: %@", mutableUserInfo);
         [FirebasePlugin.firebasePlugin _logMessage:[NSString stringWithFormat:@"didReceiveRemoteNotification: %@", mutableUserInfo]];
 
         completionHandler(UIBackgroundFetchResultNewData);
         if([self.applicationInBackground isEqual:[NSNumber numberWithBool:YES]] && isContentAvailable){
-            NSLog(@"FCM_TEST: Omitting foreground notification (background + content-available)");
             [FirebasePlugin.firebasePlugin _logError:@"didReceiveRemoteNotification: omitting foreground notification as content-available:1 so system notification will be shown"];
         }else{
-            NSLog(@"FCM_TEST: Processing message for foreground notification");
             [self processMessageForForegroundNotification:mutableUserInfo];
         }
         if([self.applicationInBackground isEqual:[NSNumber numberWithBool:YES]] || !isContentAvailable){
-            NSLog(@"FCM_TEST: Calling sendNotification to Firebase plugin");
             [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
-        } else {
-            NSLog(@"FCM_TEST: NOT calling sendNotification (foreground + content-available)");
         }
     }@catch (NSException *exception) {
         [FirebasePlugin.firebasePlugin handlePluginExceptionWithoutContext:exception];
@@ -409,9 +380,6 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
          withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
 
     @try{
-        NSLog(@"FCM_TEST: willPresentNotification - Notification arrived while app in foreground");
-        NSLog(@"FCM_TEST: Notification content: %@", notification.request.content.userInfo);
-        NSLog(@"FCM_TEST: Notification trigger type: %@", NSStringFromClass([notification.request.trigger class]));
 
         if (![notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class] && ![notification.request.trigger isKindOfClass:UNTimeIntervalNotificationTrigger.class]) {
             if (_prevUserNotificationCenterDelegate) {
@@ -453,11 +421,7 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
         bool hasBadge = [aps objectForKey:@"badge"] != nil;
         bool hasSound = [aps objectForKey:@"sound"] != nil;
 
-        NSLog(@"FCM_TEST: showForegroundNotification: %@", showForegroundNotification ? @"YES" : @"NO");
-        NSLog(@"FCM_TEST: hasAlert: %@, hasBadge: %@, hasSound: %@", hasAlert ? @"YES" : @"NO", hasBadge ? @"YES" : @"NO", hasSound ? @"YES" : @"NO");
-
         if(showForegroundNotification){
-            NSLog(@"FCM_TEST: Will show foreground notification with specified options");
             [FirebasePlugin.firebasePlugin _logMessage:[NSString stringWithFormat:@"willPresentNotification: foreground notification alert=%@, badge=%@, sound=%@", hasAlert ? @"YES" : @"NO", hasBadge ? @"YES" : @"NO", hasSound ? @"YES" : @"NO"]];
             if(hasAlert && hasBadge && hasSound){
                 completionHandler(UNNotificationPresentationOptionAlert + UNNotificationPresentationOptionBadge + UNNotificationPresentationOptionSound);
@@ -475,15 +439,11 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
                 completionHandler(UNNotificationPresentationOptionSound);
             }
         }else{
-            NSLog(@"FCM_TEST: Not showing foreground notification (notification_foreground not set)");
             [FirebasePlugin.firebasePlugin _logMessage:@"willPresentNotification: foreground notification not set"];
         }
 
         if(![messageType isEqualToString:@"data"]){
-            NSLog(@"FCM_TEST: Calling sendNotification from willPresentNotification (messageType: %@)", messageType);
             [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
-        } else {
-            NSLog(@"FCM_TEST: Not calling sendNotification (messageType is 'data')");
         }
 
     }@catch (NSException *exception) {
@@ -498,10 +458,6 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
           withCompletionHandler:(void (^)(void))completionHandler
 {
     @try{
-        NSLog(@"FCM_TEST: PUSH_TAP - didReceiveNotificationResponse - User tapped notification");
-        NSLog(@"FCM_TEST: PUSH_TAP - Action identifier: %@", response.actionIdentifier);
-        NSLog(@"FCM_TEST: PUSH_TAP - Response userInfo: %@", response.notification.request.content.userInfo);
-        NSLog(@"FCM_TEST: PUSH_TAP - App background state: %@", self.applicationInBackground);
 
         if (![response.notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class] && ![response.notification.request.trigger isKindOfClass:UNTimeIntervalNotificationTrigger.class]) {
             if (_prevUserNotificationCenterDelegate) {
@@ -525,30 +481,23 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
         NSString* tap;
         if([self.applicationInBackground isEqual:[NSNumber numberWithBool:YES]]){
             tap = @"background";
-            NSLog(@"FCM_TEST: PUSH_TAP - Setting tap to 'background'");
         }else{
             tap = @"foreground";
-            NSLog(@"FCM_TEST: PUSH_TAP - Setting tap to 'foreground'");
+
         }
         [mutableUserInfo setValue:tap forKey:@"tap"];
         if([mutableUserInfo objectForKey:@"messageType"] == nil){
             [mutableUserInfo setValue:@"notification" forKey:@"messageType"];
-            NSLog(@"FCM_TEST: PUSH_TAP - Set messageType to 'notification'");
         }
 
         // Dynamic Actions
         if (response.actionIdentifier && ![response.actionIdentifier isEqual:UNNotificationDefaultActionIdentifier]) {
-            NSLog(@"FCM_TEST: PUSH_TAP - Adding custom action: %@", response.actionIdentifier);
             [mutableUserInfo setValue:response.actionIdentifier forKey:@"action"];
-        } else {
-            NSLog(@"FCM_TEST: PUSH_TAP - Default action (regular tap)");
         }
 
         // Print full message.
-        NSLog(@"FCM_TEST: PUSH_TAP - Final processed userInfo for notification tap: %@", mutableUserInfo);
         [FirebasePlugin.firebasePlugin _logInfo:[NSString stringWithFormat:@"didReceiveNotificationResponse: %@", mutableUserInfo]];
 
-        NSLog(@"FCM_TEST: PUSH_TAP - Calling sendNotification from didReceiveNotificationResponse");
         [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
 
         completionHandler();

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -44,6 +44,7 @@ static BOOL pluginInitialized = NO;
 static BOOL registeredForRemoteNotifications = NO;
 static BOOL openSettingsEmitted = NO;
 static BOOL immediateMessagePayloadDelivery = NO;
+BOOL webViewReady = YES;  // 기본적으로 준비됨으로 가정 (optimistic approach)
 static NSMutableDictionary* authCredentials;
 static NSString* currentNonce; // used for Apple Sign In
 static FIRFirestore* firestore;
@@ -77,8 +78,20 @@ static NSMutableArray* pendingGlobalJS = nil;
 
 // @override abstract
 - (void)pluginInitialize {
-    NSLog(@"Starting Firebase plugin");
+    NSLog(@"SIMPLE_TEST: Firebase plugin is initializing");
+    NSLog(@"FCM_TEST: Starting Firebase plugin initialization");
+    NSLog(@"FCM_TEST: INIT_STATE_CHECK - Existing notificationStack: %@", self.notificationStack ? [NSString stringWithFormat:@"EXISTS (count: %lu)", (unsigned long)[self.notificationStack count]] : @"NIL");
+    NSLog(@"FCM_TEST: INIT_STATE_CHECK - Existing notificationCallbackId: %@", self.notificationCallbackId ? @"SET" : @"NIL");
+
+    // 콜드 스타트: webView는 기본적으로 준비됨으로 가정
+    // webViewReady는 이미 YES로 초기화됨 (문제 발생 시에만 NO로 설정)
+    NSLog(@"FCM_TEST: COLD_START_INIT - webViewReady: %@", webViewReady ? @"YES" : @"NO");
+
+    [self logToFile:@"Firebase plugin initialization started"];
     firebasePlugin = self;
+
+    // WKWebView delegate 설정 (FirebasePlugin에서 직접 관리)
+    [self setupWebViewDelegate];
 
     @try {
         preferences = [NSUserDefaults standardUserDefaults];
@@ -139,8 +152,12 @@ static NSMutableArray* pendingGlobalJS = nil;
         traces = [[NSMutableDictionary alloc] init];
 
         pluginInitialized = YES;
+        NSLog(@"FCM_TEST: Firebase plugin initialization completed successfully");
+        NSLog(@"FCM_TEST: immediateMessagePayloadDelivery: %@", immediateMessagePayloadDelivery ? @"YES" : @"NO");
+        NSLog(@"FCM_TEST: FCM enabled: %@", self.isFCMEnabled ? @"YES" : @"NO");
         [self executePendingGlobalJavascript];
     }@catch (NSException *exception) {
+        NSLog(@"FCM_TEST: Firebase plugin initialization failed with exception: %@", exception.reason);
         [self handlePluginExceptionWithoutContext:exception];
     }
 }
@@ -573,20 +590,76 @@ static NSMutableArray* pendingGlobalJS = nil;
 }
 
 - (void)onMessageReceived:(CDVInvokedUrlCommand *)command {
+    NSLog(@"FCM_TEST: onMessageReceived called with callbackId: %@", command.callbackId);
+    NSLog(@"FCM_TEST: WEBVIEW_STATUS_CHECK - Previous callbackId was: %@", self.notificationCallbackId ? @"SET" : @"NIL");
+    NSLog(@"FCM_TEST: WEBVIEW_STATUS_CHECK - CallbackId changed: %@",
+          [command.callbackId isEqualToString:self.notificationCallbackId ?: @""] ? @"NO (same)" : @"YES (different)");
+
+    // onMessageReceived 호출 = JavaScript 엔진 + Cordova Bridge 완전 준비!
+    // 이것이 didFinishNavigation보다 더 정확한 웹뷰 준비 신호
+    extern BOOL webViewReady;
+    NSLog(@"FCM_TEST: JS_BRIDGE_READY - onMessageReceived called, webViewReady before: %@", webViewReady ? @"YES" : @"NO");
+    webViewReady = YES;
+    NSLog(@"FCM_TEST: JS_BRIDGE_READY - webViewReady set to YES (JavaScript bridge confirmed working)");
+
+    [self logToFile:[NSString stringWithFormat:@"onMessageReceived called with callbackId: %@", command.callbackId]];
     self.notificationCallbackId = command.callbackId;
+    NSLog(@"FCM_TEST: notificationStack count before sendPending: %lu", (unsigned long)[self.notificationStack count]);
+    [self logToFile:[NSString stringWithFormat:@"notificationStack count: %lu", (unsigned long)[self.notificationStack count]]];
     [self sendPendingNotifications];
 }
 
+- (BOOL)isWebViewReadyForMessages {
+    // WKWebView delegate 기반: 가장 정확하고 신뢰할 수 있는 방법
+    NSLog(@"FCM_TEST: WEBVIEW_READINESS - webViewReady: %@", webViewReady ? @"YES" : @"NO");
+    return webViewReady;
+}
+
+// 외부에서 호출 가능한 대기 중인 알림 처리 메서드
++ (void)tryFlushPendingNotifications {
+    if (firebasePlugin) {
+        NSLog(@"FCM_TEST: FLUSH_TRIGGERED - External flush request received");
+        [firebasePlugin sendPendingNotifications];
+    } else {
+        NSLog(@"FCM_TEST: FLUSH_TRIGGERED - FirebasePlugin not initialized yet");
+    }
+}
+
 - (void)sendPendingNotifications {
+    NSLog(@"FCM_TEST: sendPendingNotifications called");
+    NSLog(@"FCM_TEST: notificationCallbackId: %@", self.notificationCallbackId ? @"SET" : @"NIL");
+    NSLog(@"FCM_TEST: notificationStack: %@", self.notificationStack ? @"EXISTS" : @"NIL");
+    NSLog(@"FCM_TEST: notificationStack count: %lu", self.notificationStack ? (unsigned long)[self.notificationStack count] : 0);
+
+    // 웹뷰 준비 상태 확인
+    BOOL isReady = [self isWebViewReadyForMessages];
+    NSLog(@"FCM_TEST: WEBVIEW_READY_CHECK - Result: %@", isReady ? @"YES" : @"NO");
+
     if (self.notificationCallbackId != nil && self.notificationStack != nil && [self.notificationStack count]) {
-        @try {
-            for (NSDictionary *userInfo in self.notificationStack) {
-                [self sendNotification:userInfo];
+        if (isReady) {
+            NSLog(@"FCM_TEST: SAFE_SEND - WebView ready, sending %lu pending notifications", (unsigned long)[self.notificationStack count]);
+            @try {
+                int notificationIndex = 0;
+                for (NSDictionary *userInfo in self.notificationStack) {
+                    NSLog(@"FCM_TEST: SAFE_SEND - Processing pending notification #%d: %@", notificationIndex++, userInfo);
+                    [self sendNotification:userInfo];
+                }
+                NSLog(@"FCM_TEST: SAFE_SEND - Clearing notificationStack - removing all %lu objects", (unsigned long)[self.notificationStack count]);
+                [self.notificationStack removeAllObjects];
+                NSLog(@"FCM_TEST: SAFE_SEND - NotificationStack cleared. New count: %lu", (unsigned long)[self.notificationStack count]);
+            } @catch (NSException *exception) {
+                NSLog(@"FCM_TEST: Exception in sendPendingNotifications: %@", exception.reason);
+                [self handlePluginExceptionWithoutContext:exception];
             }
-            [self.notificationStack removeAllObjects];
-        } @catch (NSException *exception) {
-            [self handlePluginExceptionWithoutContext:exception];
+        } else {
+            NSLog(@"FCM_TEST: WAIT_FOR_WEBVIEW - WebView not ready, keeping %lu notifications in stack", (unsigned long)[self.notificationStack count]);
+            NSLog(@"FCM_TEST: WAIT_FOR_WEBVIEW - Will retry when onMessageReceived is called");
         }
+    } else {
+        NSLog(@"FCM_TEST: Not sending pending notifications - conditions not met (callbackId: %@, stack: %@, count: %lu)",
+              self.notificationCallbackId ? @"SET" : @"NIL",
+              self.notificationStack ? @"EXISTS" : @"NIL",
+              self.notificationStack ? (unsigned long)[self.notificationStack count] : 0);
     }
 }
 
@@ -625,25 +698,57 @@ static NSMutableArray* pendingGlobalJS = nil;
 
 - (void)sendNotification:(NSDictionary *)userInfo {
     @try {
+        NSLog(@"FCM_TEST: sendNotification called with userInfo: %@", userInfo);
+        [self logToFile:[NSString stringWithFormat:@"sendNotification called - backgroundState: %@, callbackId: %@",
+                        AppDelegate.instance.applicationInBackground,
+                        self.notificationCallbackId ? @"SET" : @"NIL"]];
+        NSLog(@"FCM_TEST: App background state: %@", AppDelegate.instance.applicationInBackground);
+        NSLog(@"FCM_TEST: immediateMessagePayloadDelivery: %@", immediateMessagePayloadDelivery ? @"YES" : @"NO");
+        NSLog(@"FCM_TEST: notificationCallbackId exists: %@", self.notificationCallbackId ? @"YES" : @"NO");
+
         if([FirebasePluginMessageReceiverManager sendNotification:userInfo]){
+            NSLog(@"FCM_TEST: Message handled by custom receiver - returning early");
             [self _logMessage:@"Message handled by custom receiver"];
             return;
         }
-        if (self.notificationCallbackId != nil && ([AppDelegate.instance.applicationInBackground isEqual:@(NO)] || immediateMessagePayloadDelivery )) {
+
+        // 업계 표준: 완전한 웹뷰 준비 상태 확인
+        BOOL isReady = [self isWebViewReadyForMessages];
+        BOOL shouldSendImmediately = (self.notificationCallbackId != nil &&
+                                      ([AppDelegate.instance.applicationInBackground isEqual:@(NO)] || immediateMessagePayloadDelivery) &&
+                                      isReady);
+        NSLog(@"FCM_TEST: Should send immediately: %@", shouldSendImmediately ? @"YES" : @"NO");
+        NSLog(@"FCM_TEST: SEND_DECISION - callbackId: %@, foreground: %@, webViewReady: %@",
+              self.notificationCallbackId ? @"YES" : @"NO",
+              [AppDelegate.instance.applicationInBackground isEqual:@(NO)] ? @"YES" : @"NO",
+              isReady ? @"YES" : @"NO");
+
+        if (shouldSendImmediately) {
+            NSLog(@"FCM_TEST: IMMEDIATE_SEND - Sending notification immediately to webview via callback");
             [self sendPluginDictionaryResultAndKeepCallback:userInfo command:self.commandDelegate callbackId:self.notificationCallbackId];
         } else {
+            NSLog(@"FCM_TEST: STACK_ADD - Adding notification to stack for later delivery");
             if (!self.notificationStack) {
+                NSLog(@"FCM_TEST: STACK_ADD - Creating new notificationStack");
                 self.notificationStack = [[NSMutableArray alloc] init];
             }
 
+            NSLog(@"FCM_TEST: STACK_ADD - Current stack count before add: %lu", (unsigned long)[self.notificationStack count]);
+
             // stack notifications until a callback has been registered
             [self.notificationStack addObject:userInfo];
+            NSLog(@"FCM_TEST: STACK_ADD - Added notification to stack. New count: %lu", (unsigned long)[self.notificationStack count]);
 
             if ([self.notificationStack count] >= kNotificationStackSize) {
+                NSLog(@"FCM_TEST: STACK_ADD - Stack size limit reached (%d). Removing oldest notification", (int)kNotificationStackSize);
                 [self.notificationStack removeLastObject];
+                NSLog(@"FCM_TEST: STACK_ADD - Removed oldest notification. Final count: %lu", (unsigned long)[self.notificationStack count]);
             }
+
+            NSLog(@"FCM_TEST: STACK_ADD - Final notificationStack contents: %@", self.notificationStack);
         }
     }@catch (NSException *exception) {
+        NSLog(@"FCM_TEST: Exception in sendNotification: %@", exception.reason);
         [self handlePluginExceptionWithContext:exception :self.commandDelegate];
     }
 }
@@ -2763,9 +2868,13 @@ static NSMutableArray* pendingGlobalJS = nil;
 }
 
 - (void) sendPluginDictionaryResultAndKeepCallback:(NSDictionary*)result command:(CDVInvokedUrlCommand*)command callbackId:(NSString*)callbackId {
+    NSLog(@"FCM_TEST: WEBVIEW_SEND - sendPluginDictionaryResultAndKeepCallback called");
+    NSLog(@"FCM_TEST: WEBVIEW_SEND - CallbackId: %@", callbackId);
+    NSLog(@"FCM_TEST: WEBVIEW_SEND - Result data: %@", result);
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
     [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+    NSLog(@"FCM_TEST: WEBVIEW_SEND - Plugin result sent to webview successfully");
 }
 
 - (void) sendPluginArrayResult:(NSArray*)result command:(CDVInvokedUrlCommand*)command callbackId:(NSString*)callbackId {
@@ -3207,6 +3316,100 @@ static NSMutableArray* pendingGlobalJS = nil;
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Notification categories setup successfully"];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
+}
+
+// File logging method for debugging
+- (void)logToFile:(NSString*)message {
+    NSString *timestamp = [NSDateFormatter localizedStringFromDate:[NSDate date]
+                                                         dateStyle:NSDateFormatterShortStyle
+                                                         timeStyle:NSDateFormatterMediumStyle];
+    NSString *logMessage = [NSString stringWithFormat:@"[%@] %@\n", timestamp, message];
+
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsPath = [paths objectAtIndex:0];
+    NSString *filePath = [documentsPath stringByAppendingPathComponent:@"fcm_test_log.txt"];
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
+        [[NSFileManager defaultManager] createFileAtPath:filePath contents:nil attributes:nil];
+    }
+
+    NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:filePath];
+    [fileHandle seekToEndOfFile];
+    [fileHandle writeData:[logMessage dataUsingEncoding:NSUTF8StringEncoding]];
+    [fileHandle closeFile];
+
+    NSLog(@"FCM_FILE_LOG: %@", message);
+}
+
+#pragma mark - WKWebView Delegate Setup
+
+- (void)setupWebViewDelegate {
+    NSLog(@"FCM_TEST: PLUGIN_DELEGATE_SETUP - Setting up WebView delegate in FirebasePlugin");
+
+    // Cordova 플러그인에서 webView 접근
+    UIWebView *cordovaWebView = self.webView;
+    CDVViewController *viewController = (CDVViewController *)self.viewController;
+
+    NSLog(@"FCM_TEST: PLUGIN_DELEGATE_SETUP - CordovaWebView: %@", cordovaWebView ? @"EXISTS" : @"NIL");
+    NSLog(@"FCM_TEST: PLUGIN_DELEGATE_SETUP - ViewController: %@", viewController ? @"EXISTS" : @"NIL");
+
+    if (viewController && viewController.webView) {
+        NSLog(@"FCM_TEST: PLUGIN_DELEGATE_SETUP - ViewController webView type: %@", NSStringFromClass([viewController.webView class]));
+
+        if ([viewController.webView isKindOfClass:[WKWebView class]]) {
+            WKWebView *wkWebView = (WKWebView *)viewController.webView;
+            wkWebView.navigationDelegate = self;
+            NSLog(@"FCM_TEST: PLUGIN_DELEGATE_SETUP - WKWebView navigation delegate set to FirebasePlugin");
+            NSLog(@"FCM_TEST: PLUGIN_DELEGATE_SETUP - Current delegate: %@", wkWebView.navigationDelegate);
+        } else {
+            NSLog(@"FCM_TEST: PLUGIN_DELEGATE_SETUP - Warning: webView is not WKWebView, type: %@", NSStringFromClass([viewController.webView class]));
+        }
+    } else {
+        NSLog(@"FCM_TEST: PLUGIN_DELEGATE_SETUP - Warning: Cannot access webView from viewController");
+
+        // 대안: 지연된 설정 시도
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [self retryWebViewDelegateSetup];
+        });
+    }
+}
+
+- (void)retryWebViewDelegateSetup {
+    NSLog(@"FCM_TEST: PLUGIN_DELEGATE_RETRY - Retrying WebView delegate setup");
+
+    CDVViewController *viewController = (CDVViewController *)self.viewController;
+    if (viewController && viewController.webView && [viewController.webView isKindOfClass:[WKWebView class]]) {
+        WKWebView *wkWebView = (WKWebView *)viewController.webView;
+        wkWebView.navigationDelegate = self;
+        NSLog(@"FCM_TEST: PLUGIN_DELEGATE_RETRY - Success: WKWebView delegate set on retry");
+    } else {
+        NSLog(@"FCM_TEST: PLUGIN_DELEGATE_RETRY - Failed: Still cannot access WKWebView");
+    }
+}
+
+#pragma mark - WKNavigationDelegate
+
+// 웹뷰 페이지 로딩 완료 (보완적 fallback)
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    NSLog(@"FCM_TEST: WEBVIEW_LOADED - didFinishNavigation called (page loaded)");
+    NSLog(@"FCM_TEST: WEBVIEW_LOADED - Current webViewReady: %@", webViewReady ? @"YES" : @"NO");
+
+    // 보완 로직: onMessageReceived가 호출되지 않은 경우를 대비
+    webViewReady = YES;
+}
+
+// 웹뷰 프로세스 종료 (메모리 부족 등)
+- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView {
+    NSLog(@"FCM_TEST: WEBVIEW_TERMINATED - webViewWebContentProcessDidTerminate called in FirebasePlugin");
+    webViewReady = NO;
+    NSLog(@"FCM_TEST: WEBVIEW_TERMINATED - webViewReady set to NO, notifications will be queued");
+}
+
+// 웹뷰 로딩 실패
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    NSLog(@"FCM_TEST: WEBVIEW_ERROR - didFailNavigation: %@", error.localizedDescription);
+    // 에러 상황에서는 webViewReady를 NO로 설정
+    webViewReady = NO;
 }
 
 @end


### PR DESCRIPTION
- https://github.com/hogangnono/hogangnono-phonegap/pull/253

### 작업내용
- 푸시 딥링크 손실(issue: 웹뷰 재시작)을 잡으려고 AppDelegate/FirebasePlugin 쪽에서 WKWebView 라이프사이클을 직접 컨트롤 함에 따라 다른 delegate 사용처에 부작용이 생김
- FirebasePlugin의 delegate 훅을 조정해서 originWebview로 이벤트를 넘기는 방식 적용 및 테스트
- 아예 navigationDelegate 교체 없이 NotificationCenter만으로 WKWebView 종료를 모니터링하도록 시도. 플러그인 내부에서 delegate를 건드리지 않아 사이드이펙트를 줄이는 목표였지만, 실제 termination 재현 시 알림 수신이 불안정 확인
- termination 감지를 확실히 하기 위해 delegate 프록시를 다시 도입. 기존 delegate를 약하게 참조해 termination 콜백만 가로채고, 나머지 메서드는 그대로 포워딩하도록 구성