### PR TITLE
[HGNN-12792] 입주민 채팅 : 관리자 전송 푸시 메세지에 null 표시

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebasex",
-  "version": "18.1.4-hogangnono",
+  "version": "18.1.5-hogangnono",
   "description": "Cordova plugin for Google Firebase",
   "types": "./types/index.d.ts",
   "author": {

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -203,7 +203,7 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                         String sendbirdJson = data.get("sendbird");
                         if (sendbirdJson != null) {
                             if (title == null) {
-                                if (sendbirdJson.contains("push_title")) {
+                                if (parseJsonString(sendbirdJson, "push_title") != null) {
                                     title = parseJsonString(sendbirdJson, "push_title");
                                 } else {
                                     title = getApplicationInfo().loadLabel(getPackageManager()).toString();
@@ -538,7 +538,7 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
     private String parseJsonString(String jsonString, String key) {
         try {
             JSONObject jsonObject = new JSONObject(jsonString);
-            if (jsonObject.has(key)) {
+            if (jsonObject.has(key) && !jsonObject.isNull(key)) {
                 String value = jsonObject.getString(key);
                 return decodeStringValue(value);
             }

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -203,8 +203,8 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                         String sendbirdJson = data.get("sendbird");
                         if (sendbirdJson != null) {
                             if (title == null) {
-                                if (parseJsonString(sendbirdJson, "push_title") != null) {
-                                    title = parseJsonString(sendbirdJson, "push_title");
+                                if (parseJsonString(sendbirdJson, "pushTitle") != null) {
+                                    title = parseJsonString(sendbirdJson, "pushTitle");
                                 } else {
                                     title = getApplicationInfo().loadLabel(getPackageManager()).toString();
                                 }

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -202,8 +202,12 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                     try {
                         String sendbirdJson = data.get("sendbird");
                         if (sendbirdJson != null) {
-                            if (title == null && sendbirdJson.contains("push_title")) {
-                                title = parseJsonString(sendbirdJson, "push_title");
+                            if (title == null) {
+                                if (sendbirdJson.contains("push_title")) {
+                                    title = parseJsonString(sendbirdJson, "push_title");
+                                } else {
+                                    title = getApplicationInfo().loadLabel(getPackageManager()).toString();
+                                }
                             }
 
                             if (sendbirdJson.contains("type")) {


### PR DESCRIPTION
https://zigbang.atlassian.net/browse/HGNN-12792

- sendbird admin 푸시 배너 타이틀이 null 로 표기되는 현상
- push payload json 파싱시 null 값을 "null" 문자열로 리턴하여 발생
- 파싱시 null체크 추가하여 해결