### PR TITLE
[HGNN-13856] Firebase iOS SDK 11.8.0 → 11.14.0 (18.1.5-hogangnono)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebasex",
-  "version": "18.1.4-hogangnono",
+  "version": "18.1.5-hogangnono",
   "description": "Cordova plugin for Google Firebase",
   "types": "./types/index.d.ts",
   "author": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-firebasex" version="18.1.1-hogangnono"
+<plugin id="cordova-plugin-firebasex" version="18.1.5-hogangnono"
 	xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"

--- a/plugin.xml
+++ b/plugin.xml
@@ -181,19 +181,19 @@
 				<source url="https://cdn.cocoapods.org/"/>
 			</config>
 			<pods use-frameworks="true">
-				<pod name="FirebaseCore" spec="11.8.0"/>
-				<pod name="FirebaseCoreExtension" spec="11.8.0"/>
-				<pod name="FirebaseAuth" spec="11.8.1"/>
-				<pod name="FirebaseAnalytics" spec="11.8.0"/>
-				<!--<pod name="FirebaseAnalyticsOnDeviceConversion" spec="11.8.0"/>-->
-				<pod name="FirebaseMessaging" spec="11.8.0"/>
-				<pod name="FirebasePerformance" spec="11.8.0"/>
-				<pod name="FirebaseRemoteConfig" spec="11.8.0"/>
-				<pod name="FirebaseInAppMessaging" spec="11.8.0-beta"/>
-				<pod name="FirebaseFirestore" spec="11.8.0"/>
-				<pod name="FirebaseCrashlytics" spec="11.8.0"/>
-				<pod name="FirebaseFunctions" spec="11.8.0"/>
-				<pod name="FirebaseInstallations" spec="11.8.0"/>
+				<pod name="FirebaseCore" spec="11.14.0"/>
+				<pod name="FirebaseCoreExtension" spec="11.14.0"/>
+				<pod name="FirebaseAuth" spec="11.14.0"/>
+				<pod name="FirebaseAnalytics" spec="11.14.0"/>
+				<!--<pod name="FirebaseAnalyticsOnDeviceConversion" spec="11.14.0"/>-->
+				<pod name="FirebaseMessaging" spec="11.14.0"/>
+				<pod name="FirebasePerformance" spec="11.14.0"/>
+				<pod name="FirebaseRemoteConfig" spec="11.14.0"/>
+				<pod name="FirebaseInAppMessaging" spec="11.14.0-beta"/>
+				<pod name="FirebaseFirestore" spec="11.14.0"/>
+				<pod name="FirebaseCrashlytics" spec="11.14.0"/>
+				<pod name="FirebaseFunctions" spec="11.14.0"/>
+				<pod name="FirebaseInstallations" spec="11.14.0"/>
 				<pod name="GoogleSignIn" spec="7.1.0"/>
 				<pod name="GoogleTagManager" spec="8.0.0"/>
 			</pods>


### PR DESCRIPTION
## Summary
- Firebase iOS SDK 버전 업그레이드: 11.8.0 → 11.14.0
- plugin.xml 내 모든 Firebase pod spec 업데이트
- package.json 버전 bump: 18.1.4-hogangnono → 18.1.5-hogangnono

## 배경
ICM(Improved Conversion Measurement / 확률적 모델링) 도입 요건:
- Firebase iOS SDK ≥ 11.14.0: ATT 응답 기반 Consent Mode v2 자동 처리 포함
- Jira: https://zigbang.atlassian.net/browse/HGNN-13856

## 변경 파일
- `plugin.xml`: Firebase pod spec 11.8.0 → 11.14.0 (FirebaseAuth 11.8.1 → 11.14.0 포함)
- `package.json`: version 18.1.5-hogangnono

## 참고
- `feature/HGNN-12792`도 18.1.5-hogangnono 예약 중 — 먼저 머지되는 PR이 해당 버전 사용, 나머지는 18.1.6으로 bump 필요

## Test plan
- [ ] 머지 후 npm publish 18.1.5-hogangnono to npm.housefeed.com
- [ ] hogangnono-phonegap2 package.json 18.1.4-hogangnono → 18.1.5-hogangnono 업데이트
- [ ] npm install → cordova prepare ios → pod install 실행 확인
- [ ] pod install 결과 Firebase 11.14.0 확인
- [ ] Q-ICM-009: 사내 iOS 테스트 빌드 → Google Ads 콘솔 ICM 신호 활성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)